### PR TITLE
Fix V730 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/components/PolygonalPrism.h
+++ b/src/components/PolygonalPrism.h
@@ -49,7 +49,8 @@ public:
 	PolygonalPrism() :
 		AbstractPart(),
 		_base(),
-		_height(0)
+                _height(0),
+                _centered(true)
 	{
 		rebuild();
 	}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Not all members of a class are initialized inside the constructor.
Consider inspecting: _centered.