### PR TITLE
Three important improvements for OOML

### DIFF
--- a/src/components/RoundedCylinder.h
+++ b/src/components/RoundedCylinder.h
@@ -127,7 +127,7 @@ public:
 			cornerRadius = height / 2;
 
 		Component cylinder(Cylinder(radius1 - cornerRadius, radius2 - cornerRadius, height - cornerRadius, faces, center));
-		Component sphere(Sphere(cornerRadius, faces, center));
+		Component sphere(Sphere(cornerRadius, faces));
 		sphere.translate(radius1 - cornerRadius, 0.0, height - cornerRadius);
 
 		set(MinkowskiDecorator::create(cylinder.get(), sphere.get()).get());

--- a/src/components/Sphere.h
+++ b/src/components/Sphere.h
@@ -48,14 +48,13 @@ public:
 	 *
 	 * Creates a sphere to use in other components.
 	 *
-	 * \param radius Cylinder radius.
-	 * \param faces Number of faces of the rendered cylinder.
-	 * \param center Centered cylinder flag.
+	 * \param radius Sphere radius.
+	 * \param faces Number of faces of the rendered sphere.
 	 *
 	 */
-	static Component create(double radius, unsigned int faces=100, bool center=true)
+	static Component create(double radius, unsigned int faces=100)
 	{
-        return SphereObject::create(radius,faces,center);
+        return SphereObject::create(radius,faces);
 	}
 
 	/**
@@ -64,26 +63,23 @@ public:
 	Sphere() :
         Component(),
 		_radius(1.0),
-		_faces(50),
-		_center(true)
+		_faces(50)
     {
-        Component sph = SphereObject::create(_radius,_faces,_center);
+        Component sph = SphereObject::create(_radius,_faces);
         set(sph.get());
     }
 	/**
 	 * \brief Default parametrized constructor.
 	 *
-	 * \param radius Cylinder radius.
-	 * \param faces Number of faces of the rendered cylinder.
-	 * \param center Centered cylinder flag.
+	 * \param radius Sphere radius.
+	 * \param faces Number of faces of the rendered sphere.
 	 */
-	Sphere(double radius, unsigned int faces=100, bool center=true) :
+	Sphere(double radius, unsigned int faces=100) :
         Component(),
 		_radius(radius),
-		_faces(faces),
-		_center(center)
+		_faces(faces)
     {
-        Component sph = SphereObject::create(_radius,_faces,_center);
+        Component sph = SphereObject::create(_radius,_faces);
         set(sph.get());
     }
 	/**
@@ -93,8 +89,7 @@ public:
 
 private:
 	double _radius; /** Sphere radius. */
-	unsigned int _faces; /** Number of faces of the rendered cylinder. */
-	bool _center; /** Centered cylinder flag. */
+	unsigned int _faces; /** Number of faces of the rendered sphere. */
 };
 
 

--- a/src/core/Hull.h
+++ b/src/core/Hull.h
@@ -36,9 +36,9 @@
 #include <core/IndentWriter.h>
 
 /**
- * \brief Union object.
+ * \brief Hull object.
  *
- * This class joins multiple objects into a union object.
+ * This class forms a convex hull object around multiple objects.
  */
 class OOMLCore_EXP_DEC Hull : public CompositeObject
 {
@@ -47,9 +47,9 @@ public:
   /**
    * \brief Static factory method.
    *
-   * Creates a union to use in other components.
+   * Creates a hull to use in other components.
    *
-   * \return A union component.
+   * \return A hull component.
    */
   static CompositeComponent create()
   {

--- a/src/core/Point2D.h
+++ b/src/core/Point2D.h
@@ -228,4 +228,24 @@ private:
 	double _y; /** Point position in the y axis. */
 };
 
+template<>
+struct std::hash<Point2D>
+{
+    std::size_t operator()(const Point2D& p) const
+    {
+      std::hash<double> hf;
+      return hf(p.getX()) ^ hf(p.getY());
+    }
+};
+
+template<>
+struct std::equal_to<Point2D>
+{
+    bool operator()(const Point2D& a, const Point2D& b) const
+    {
+      return (a.getX() == b.getX() &&
+	      a.getY() == b.getY());
+    }
+};
+
 #endif // POINT2D_H_INCLUDED

--- a/src/core/Point3D.h
+++ b/src/core/Point3D.h
@@ -239,4 +239,25 @@ protected:
     double _z; /** Point position in the z axis. */
 };
 
+template<>
+struct std::hash<Point3D>
+{
+    std::size_t operator()(const Point3D& p) const
+    {
+      std::hash<double> hf;
+      return hf(p.getX()) ^ hf(p.getY()) ^ hf(p.getZ());
+    }
+};
+
+template<>
+struct std::equal_to<Point3D>
+{
+    bool operator()(const Point3D& a, const Point3D& b) const
+    {
+      return (a.getX() == b.getX() &&
+              a.getY() == b.getY() &&
+              a.getZ() == b.getZ());
+    }
+};
+
 #endif // POINT3D_H_INCLUDED

--- a/src/core/PointIndexMap.h
+++ b/src/core/PointIndexMap.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 *    OOML : Object Oriented Mechanics Library
 *    Copyright (C) 2012  Alberto Valero Gomez, Juan González Gómez, Rafael Treviño
 *
@@ -33,7 +33,7 @@
 #include <core/AbstractObject.h>
 #include <core/IndentWriter.h>
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 
 /**
@@ -90,11 +90,11 @@ public:
    */
   bool addPoint(T const& point)
   {
-    typename Map::iterator lb = _map.lower_bound(point);
-    /** Check if the point exists. */
-    if (lb == _map.end() || _map.key_comp()(point, lb->first))
+    typename Map::iterator it = _map.find(point);
+    /** Add point if it doesn't already exist. */
+    if (it == _map.end())
     {
-      _map.insert(lb, typename Map::value_type(point, _vector.size()));
+      _map.insert(typename Map::value_type(point, _vector.size()));
       _vector.push_back(typename Vector::value_type(point));
       return true;
     }
@@ -160,7 +160,8 @@ public:
 
 private:
   typedef std::vector<T> Vector; /** A vector of points. */
-  typedef std::map<T, unsigned int> Map; /** A map from points to its point index. */
+  typedef std::unordered_map<T, unsigned int, std::hash<T>, std::equal_to<T>> Map;
+      /** A map from points to its point index. */
 
   Vector _vector; /** Vector of points inside the index. */
   Map _map; /** Map of conversion from points to indexes. */

--- a/src/core/PointIndexMap.h
+++ b/src/core/PointIndexMap.h
@@ -170,13 +170,15 @@ private:
 template <typename T>
 void PointIndexMap<T>::genScad(IndentWriter& writer) const
 {
+	const char *comma = "";
+
 	writer << "[";
-	for (typename Vector::const_iterator it = _vector.begin(); ; )
+	for (typename Vector::const_iterator it = _vector.begin();
+	     it != _vector.end(); ++it )
 	{
+		writer << comma;
 		it->genScad(writer);
-		if (++it == _vector.end())
-			break;
-		writer << ", ";
+		comma = ", ";
 	}
 	writer << "]";
 }
@@ -184,13 +186,15 @@ void PointIndexMap<T>::genScad(IndentWriter& writer) const
 template <typename T>
 void PointIndexMap<T>::printAst(IndentWriter& writer) const
 {
+	const char *comma = "";
+
 	writer << "[";
-	for (typename Vector::const_iterator it = _vector.begin(); ; )
+	for (typename Vector::const_iterator it = _vector.begin();
+	     it != _vector.end(); ++it )
 	{
+		writer << comma;
 		it->printAst(writer);
-		if (++it == _vector.end())
-			break;
-		writer << ", ";
+		comma = ", ";
 	}
 	writer << "]";
 }

--- a/src/core/Polyhedron.cpp
+++ b/src/core/Polyhedron.cpp
@@ -32,30 +32,32 @@ void Polyhedron::IndexedTriangle3D::printAst(IndentWriter& writer) const
 
 void Polyhedron::genScad(IndentWriter& writer) const
 {
+	const char *comma = "";
 	writer << "polyhedron(points=";
 	_point3DIndexMap.genScad(writer);
 	writer << ", faces=[";
-	for (Triangle3DVector::const_iterator it = _triangles.begin(); ; )
+	for (Triangle3DVector::const_iterator it = _triangles.begin();
+	     it != _triangles.end(); ++it )
 	{
+		writer << comma;
 		it->genScad(writer);
-		if (++it == _triangles.end())
-			break;
-		writer << ", ";
+		comma = ", ";
 	}
         writer << "]);" << std::endl;
 }
 
 void Polyhedron::printAst(IndentWriter& writer) const
 {
+	const char *comma = "";
 	writer << "POLYHEDRON(";
 	_point3DIndexMap.printAst(writer);
 	writer << ", [";
-	for (Triangle3DVector::const_iterator it = _triangles.begin(); ; )
+	for (Triangle3DVector::const_iterator it = _triangles.begin();
+	     it != _triangles.end(); ++it )
 	{
+		writer << comma;
 		it->printAst(writer);
-		if (++it == _triangles.end())
-			break;
-		writer << ", ";
+		comma = ", ";
 	}
 	writer << "])" << std::endl;
 }

--- a/src/core/Polyhedron.cpp
+++ b/src/core/Polyhedron.cpp
@@ -34,7 +34,7 @@ void Polyhedron::genScad(IndentWriter& writer) const
 {
 	writer << "polyhedron(points=";
 	_point3DIndexMap.genScad(writer);
-	writer << ", triangles=[";
+	writer << ", faces=[";
 	for (Triangle3DVector::const_iterator it = _triangles.begin(); ; )
 	{
 		it->genScad(writer);

--- a/src/core/Polyhedron.h
+++ b/src/core/Polyhedron.h
@@ -244,7 +244,7 @@ private:
 			 * \param writer An instance of indent writer to write to.
 			 */
 			virtual void printAst(IndentWriter& writer) const;
-		
+
 		protected:
 			/**
 			 * \brief Default referenced constructor.

--- a/src/core/SphereObject.cpp
+++ b/src/core/SphereObject.cpp
@@ -24,11 +24,10 @@
 
 void SphereObject::genScad(IndentWriter& writer) const
 {
-    writer << "sphere(r=" << _radius << ", $fn=" << _faces
-        << ", center=" << _center << ");" << std::endl;
+    writer << "sphere(r=" << _radius << ", $fn=" << _faces << ");" << std::endl;
 }
 
 void SphereObject::printAst(IndentWriter& writer) const
 {
-    writer << "// SPHERE(" << _radius << ", " << _faces << ", " << _center << ")" << std::endl;
+    writer << "// SPHERE(" << _radius << ", " << _faces << ")" << std::endl;
 }

--- a/src/core/SphereObject.h
+++ b/src/core/SphereObject.h
@@ -47,14 +47,13 @@ public:
      *
      * Creates a sphere to use in other components.
      *
-     * \param radius Cylinder radius.
-     * \param faces Number of faces of the rendered cylinder.
-     * \param center Centered cylinder flag.
+     * \param radius Sphere radius.
+     * \param faces Number of faces of the rendered sphere.
      *
      */
-    static Component create(double radius, unsigned int faces=100, bool center=true)
+    static Component create(double radius, unsigned int faces=100)
     {
-        return Component(SharedPtr<AbstractObject>(new SphereObject(radius, faces, center)));
+        return Component(SharedPtr<AbstractObject>(new SphereObject(radius, faces)));
     }
 
     /**
@@ -87,21 +86,18 @@ protected:
     SphereObject() :
         AbstractObject(),
         _radius(1.0),
-        _faces(50),
-        _center(true)
+        _faces(50)
     {}
     /**
      * \brief Default parametrized constructor.
      *
-     * \param radius Cylinder radius.
-     * \param faces Number of faces of the rendered cylinder.
-     * \param center Centered cylinder flag.
+     * \param radius Sphere radius.
+     * \param faces Number of faces of the rendered sphere.
      */
-    SphereObject(double radius, unsigned int faces=100, bool center=true) :
+    SphereObject(double radius, unsigned int faces=100) :
         AbstractObject(),
         _radius(radius),
-        _faces(faces),
-        _center(center)
+        _faces(faces)
     {}
     /**
      * \brief Default destructor.
@@ -110,8 +106,7 @@ protected:
 
 private:
     double _radius; /** Sphere radius. */
-    unsigned int _faces; /** Number of faces of the rendered cylinder. */
-    bool _center; /** Centered cylinder flag. */
+    unsigned int _faces; /** Number of faces of the rendered sphere. */
 };
 
 


### PR DESCRIPTION
Fix for bug where polygons and polyhedra may not contain multiple points that are equidistant from the origin due to the way they are stored in an ordered data structure.

Fix crash when a polyhedron is empty.

Remove the "center" argument for Sphere which does not exist in OpenSCAD.